### PR TITLE
Get away from master and slave phrasing

### DIFF
--- a/AWSApps/Splunk_TA_aws/bin/3rdparty/boto/elastictranscoder/layer1.py
+++ b/AWSApps/Splunk_TA_aws/bin/3rdparty/boto/elastictranscoder/layer1.py
@@ -118,10 +118,10 @@ class ElasticTranscoderConnection(AWSAuthConnection):
         :type playlists: list
         :param playlists: If you specify a preset in `PresetId` for which the
             value of `Container` is ts (MPEG-TS), Playlists contains
-            information about the master playlists that you want Elastic
+            information about the main playlists that you want Elastic
             Transcoder to create.
-        We recommend that you create only one master playlist. The maximum
-            number of master playlists in a job is 30.
+        We recommend that you create only one main playlist. The maximum
+            number of main playlists in a job is 30.
 
         """
         uri = '/2012-09-25/jobs'

--- a/AWSApps/Splunk_TA_aws/bin/3rdparty/boto/emr/connection.py
+++ b/AWSApps/Splunk_TA_aws/bin/3rdparty/boto/emr/connection.py
@@ -408,8 +408,8 @@ class EmrConnection(AWSQueryConnection):
 
     def run_jobflow(self, name, log_uri=None, ec2_keyname=None,
                     availability_zone=None,
-                    master_instance_type='m1.small',
-                    slave_instance_type='m1.small', num_instances=1,
+                    main_instance_type='m1.small',
+                    subordinate_instance_type='m1.small', num_instances=1,
                     action_on_failure='TERMINATE_JOB_FLOW', keep_alive=False,
                     enable_debugging=False,
                     hadoop_version=None,
@@ -436,11 +436,11 @@ class EmrConnection(AWSQueryConnection):
         :type availability_zone: str
         :param availability_zone: EC2 availability zone of the cluster
 
-        :type master_instance_type: str
-        :param master_instance_type: EC2 instance type of the master
+        :type main_instance_type: str
+        :param main_instance_type: EC2 instance type of the main
 
-        :type slave_instance_type: str
-        :param slave_instance_type: EC2 instance type of the slave nodes
+        :type subordinate_instance_type: str
+        :param subordinate_instance_type: EC2 instance type of the subordinate nodes
 
         :type num_instances: int
         :param num_instances: Number of instances in the Hadoop cluster
@@ -471,7 +471,7 @@ class EmrConnection(AWSQueryConnection):
         :param instance_groups: Optional list of instance groups to
             use when creating this job.
             NB: When provided, this argument supersedes num_instances
-            and master/slave_instance_type.
+            and main/subordinate_instance_type.
 
         :type ami_version: str
         :param ami_version: Amazon Machine Image (AMI) version to use
@@ -526,15 +526,15 @@ class EmrConnection(AWSQueryConnection):
         params.update(common_params)
 
         # NB: according to the AWS API's error message, we must
-        # "configure instances either using instance count, master and
-        # slave instance type or instance groups but not both."
+        # "configure instances either using instance count, main and
+        # subordinate instance type or instance groups but not both."
         #
         # Thus we switch here on the truthiness of instance_groups.
         if not instance_groups:
             # Instance args (the common case)
             instance_params = self._build_instance_count_and_type_args(
-                                                        master_instance_type,
-                                                        slave_instance_type,
+                                                        main_instance_type,
+                                                        subordinate_instance_type,
                                                         num_instances)
             params.update(instance_params)
         else:
@@ -721,15 +721,15 @@ class EmrConnection(AWSQueryConnection):
 
         return params
 
-    def _build_instance_count_and_type_args(self, master_instance_type,
-                                            slave_instance_type, num_instances):
+    def _build_instance_count_and_type_args(self, main_instance_type,
+                                            subordinate_instance_type, num_instances):
         """
-        Takes a master instance type (string), a slave instance type
+        Takes a main instance type (string), a subordinate instance type
         (string), and a number of instances. Returns a comparable dict
         for use in making a RunJobFlow request.
         """
-        params = {'Instances.MasterInstanceType': master_instance_type,
-                  'Instances.SlaveInstanceType': slave_instance_type,
+        params = {'Instances.MainInstanceType': main_instance_type,
+                  'Instances.SubordinateInstanceType': subordinate_instance_type,
                   'Instances.InstanceCount': num_instances}
         return params
 

--- a/AWSApps/Splunk_TA_aws/bin/3rdparty/boto/emr/step.py
+++ b/AWSApps/Splunk_TA_aws/bin/3rdparty/boto/emr/step.py
@@ -132,7 +132,7 @@ class StreamingStep(Step):
         :param output: The output uri
         :type jar: str
         :param jar: The hadoop streaming jar. This can be either a local
-            path on the master node, or an s3:// URI.
+            path on the main node, or an s3:// URI.
         """
         self.name = name
         self.mapper = mapper

--- a/AWSApps/Splunk_TA_aws/bin/3rdparty/boto/kms/layer1.py
+++ b/AWSApps/Splunk_TA_aws/bin/3rdparty/boto/kms/layer1.py
@@ -130,7 +130,7 @@ class KMSConnection(AWSQueryConnection):
 
     def create_alias(self, alias_name, target_key_id):
         """
-        Creates a display name for a customer master key. An alias can
+        Creates a display name for a customer main key. An alias can
         be used to identify a key and should be unique. The console
         enforces a one-to-one mapping between the alias and a key. An
         alias name can contain only alphanumeric characters, forward
@@ -174,7 +174,7 @@ class KMSConnection(AWSQueryConnection):
         #. RevokeGrant
 
         :type key_id: string
-        :param key_id: A unique key identifier for a customer master key. This
+        :param key_id: A unique key identifier for a customer main key. This
             value can be a globally unique identifier, an ARN, or an alias.
 
         :type grantee_principal: string
@@ -222,7 +222,7 @@ class KMSConnection(AWSQueryConnection):
 
     def create_key(self, policy=None, description=None, key_usage=None):
         """
-        Creates a customer master key. Customer master keys can be
+        Creates a customer main key. Customer main keys can be
         used to encrypt small amounts of data (less than 4K) directly,
         but they are most commonly used to encrypt or envelope data
         keys that are then used to encrypt customer data. For more
@@ -306,10 +306,10 @@ class KMSConnection(AWSQueryConnection):
     def describe_key(self, key_id):
         """
         Provides detailed information about the specified customer
-        master key.
+        main key.
 
         :type key_id: string
-        :param key_id: Unique identifier of the customer master key to be
+        :param key_id: Unique identifier of the customer main key to be
             described. This can be an ARN, an alias, or a globally unique
             identifier.
 
@@ -323,7 +323,7 @@ class KMSConnection(AWSQueryConnection):
         Marks a key as disabled, thereby preventing its use.
 
         :type key_id: string
-        :param key_id: Unique identifier of the customer master key to be
+        :param key_id: Unique identifier of the customer main key to be
             disabled. This can be an ARN, an alias, or a globally unique
             identifier.
 
@@ -337,7 +337,7 @@ class KMSConnection(AWSQueryConnection):
         Disables rotation of the specified key.
 
         :type key_id: string
-        :param key_id: Unique identifier of the customer master key for which
+        :param key_id: Unique identifier of the customer main key for which
             rotation is to be disabled. This can be an ARN, an alias, or a
             globally unique identifier.
 
@@ -352,7 +352,7 @@ class KMSConnection(AWSQueryConnection):
         have up to 25 enabled keys at one time.
 
         :type key_id: string
-        :param key_id: Unique identifier of the customer master key to be
+        :param key_id: Unique identifier of the customer main key to be
             enabled. This can be an ARN, an alias, or a globally unique
             identifier.
 
@@ -363,10 +363,10 @@ class KMSConnection(AWSQueryConnection):
 
     def enable_key_rotation(self, key_id):
         """
-        Enables rotation of the specified customer master key.
+        Enables rotation of the specified customer main key.
 
         :type key_id: string
-        :param key_id: Unique identifier of the customer master key for which
+        :param key_id: Unique identifier of the customer main key for which
             rotation is to be enabled. This can be an ARN, an alias, or a
             globally unique identifier.
 
@@ -378,11 +378,11 @@ class KMSConnection(AWSQueryConnection):
     def encrypt(self, key_id, plaintext, encryption_context=None,
                 grant_tokens=None):
         """
-        Encrypts plaintext into ciphertext by using a customer master
+        Encrypts plaintext into ciphertext by using a customer main
         key.
 
         :type key_id: string
-        :param key_id: Unique identifier of the customer master. This can be an
+        :param key_id: Unique identifier of the customer main. This can be an
             ARN, an alias, or the Key ID.
 
         :type plaintext: blob
@@ -420,7 +420,7 @@ class KMSConnection(AWSQueryConnection):
                           grant_tokens=None):
         """
         Generates a secure data key. Data keys are used to encrypt and
-        decrypt data. They are wrapped by customer master keys.
+        decrypt data. They are wrapped by customer main keys.
 
         :type key_id: string
         :param key_id: Unique identifier of the key. This can be an ARN, an
@@ -472,7 +472,7 @@ class KMSConnection(AWSQueryConnection):
                                             number_of_bytes=None,
                                             grant_tokens=None):
         """
-        Returns a key wrapped by a customer master key without the
+        Returns a key wrapped by a customer main key without the
         plaintext copy of that key. To retrieve the plaintext, see
         GenerateDataKey.
 
@@ -651,7 +651,7 @@ class KMSConnection(AWSQueryConnection):
 
     def list_keys(self, limit=None, marker=None):
         """
-        Lists the customer master keys.
+        Lists the customer main keys.
 
         :type limit: integer
         :param limit: Specify this parameter only when paginating results to
@@ -702,7 +702,7 @@ class KMSConnection(AWSQueryConnection):
                    source_encryption_context=None,
                    destination_encryption_context=None, grant_tokens=None):
         """
-        Encrypts data on the server side with a new customer master
+        Encrypts data on the server side with a new customer main
         key without exposing the plaintext of the data on the client
         side. The data is first decrypted and then encrypted. This
         operation can also be used to change the encryption context of

--- a/AWSApps/Splunk_TA_aws/bin/3rdparty/boto/opsworks/layer1.py
+++ b/AWSApps/Splunk_TA_aws/bin/3rdparty/boto/opsworks/layer1.py
@@ -2124,7 +2124,7 @@ class OpsWorksConnection(AWSQueryConnection):
         :param rds_db_instance_arn: The Amazon RDS instance's ARN.
 
         :type db_user: string
-        :param db_user: The database's master user name.
+        :param db_user: The database's main user name.
 
         :type db_password: string
         :param db_password: The database password.
@@ -2785,7 +2785,7 @@ class OpsWorksConnection(AWSQueryConnection):
         :param rds_db_instance_arn: The Amazon RDS instance's ARN.
 
         :type db_user: string
-        :param db_user: The master user name.
+        :param db_user: The main user name.
 
         :type db_password: string
         :param db_password: The database password.

--- a/AWSApps/Splunk_TA_aws/bin/3rdparty/boto/pyami/bootstrap.py
+++ b/AWSApps/Splunk_TA_aws/bin/3rdparty/boto/pyami/bootstrap.py
@@ -88,7 +88,7 @@ class Bootstrap(ScriptBase):
             if update.find(':') >= 0:
                 method, version = update.split(':')
             else:
-                version = 'master'
+                version = 'main'
             self.run('git checkout %s' % version, cwd=location)
         else:
             # first remove the symlink needed when running from subversion

--- a/AWSApps/Splunk_TA_aws/bin/3rdparty/boto/rds/__init__.py
+++ b/AWSApps/Splunk_TA_aws/bin/3rdparty/boto/rds/__init__.py
@@ -138,8 +138,8 @@ class RDSConnection(AWSQueryConnection):
                           id,
                           allocated_storage,
                           instance_class,
-                          master_username,
-                          master_password,
+                          main_username,
+                          main_password,
                           port=3306,
                           engine='MySQL5.1',
                           db_name=None,
@@ -168,8 +168,8 @@ class RDSConnection(AWSQueryConnection):
         # security_groups should be db_security_groups according to API docs but has been left
         # security_groups for backwards compatibility
         #
-        # master_password should be master_user_password according to API docs but has been left
-        # master_password for backwards compatibility
+        # main_password should be main_user_password according to API docs but has been left
+        # main_password for backwards compatibility
         #
         # instance_class should be db_instance_class according to API docs but has been left
         # instance_class for backwards compatibility
@@ -222,8 +222,8 @@ class RDSConnection(AWSQueryConnection):
                        * sqlserver-web
                        * postgres
 
-        :type master_username: str
-        :param master_username: Name of master user for the DBInstance.
+        :type main_username: str
+        :param main_username: Name of main user for the DBInstance.
 
                                 * MySQL must be;
                                   - 1--16 alphanumeric characters
@@ -240,8 +240,8 @@ class RDSConnection(AWSQueryConnection):
                                   - first character must be a letter
                                   - cannot be a reserver SQL Server word
 
-        :type master_password: str
-        :param master_password: Password of master user for the DBInstance.
+        :type main_password: str
+        :param main_password: Password of main user for the DBInstance.
 
                                 * MySQL must be 8--41 alphanumeric characters
 
@@ -398,8 +398,8 @@ class RDSConnection(AWSQueryConnection):
         # engine => Engine
         # engine_version => EngineVersion
         # license_model => LicenseModel
-        # master_username => MasterUsername
-        # master_user_password => MasterUserPassword
+        # main_username => MainUsername
+        # main_user_password => MainUserPassword
         # multi_az => MultiAZ
         # option_group_name => OptionGroupName
         # port => Port
@@ -423,8 +423,8 @@ class RDSConnection(AWSQueryConnection):
                   'EngineVersion': engine_version,
                   'Iops': iops,
                   'LicenseModel': license_model,
-                  'MasterUsername': master_username,
-                  'MasterUserPassword': master_password,
+                  'MainUsername': main_username,
+                  'MainUserPassword': main_password,
                   'MultiAZ': str(multi_az).lower() if multi_az else None,
                   'OptionGroupName': option_group_name,
                   'Port': port,
@@ -562,7 +562,7 @@ class RDSConnection(AWSQueryConnection):
 
     def modify_dbinstance(self, id, param_group=None, security_groups=None,
                           preferred_maintenance_window=None,
-                          master_password=None, allocated_storage=None,
+                          main_password=None, allocated_storage=None,
                           instance_class=None,
                           backup_retention_period=None,
                           preferred_backup_window=None,
@@ -593,8 +593,8 @@ class RDSConnection(AWSQueryConnection):
                                              occur.
                                              Default is Sun:05:00-Sun:09:00
 
-        :type master_password: str
-        :param master_password: Password of master user for the DBInstance.
+        :type main_password: str
+        :param main_password: Password of main user for the DBInstance.
                                 Must be 4-15 alphanumeric characters.
 
         :type allocated_storage: int
@@ -680,8 +680,8 @@ class RDSConnection(AWSQueryConnection):
             self.build_list_params(params, l, 'VpcSecurityGroupIds.member')
         if preferred_maintenance_window:
             params['PreferredMaintenanceWindow'] = preferred_maintenance_window
-        if master_password:
-            params['MasterUserPassword'] = master_password
+        if main_password:
+            params['MainUserPassword'] = main_password
         if allocated_storage:
             params['AllocatedStorage'] = allocated_storage
         if instance_class:

--- a/AWSApps/Splunk_TA_aws/bin/3rdparty/boto/rds/dbinstance.py
+++ b/AWSApps/Splunk_TA_aws/bin/3rdparty/boto/rds/dbinstance.py
@@ -47,7 +47,7 @@ class DBInstance(object):
         in status "available".
     :ivar instance_class: Contains the name of the compute and memory
         capacity class of the DB Instance.
-    :ivar master_username: The username that is set as master username
+    :ivar main_username: The username that is set as main username
         at creation time.
     :ivar parameter_groups: Provides the list of DB Parameter Groups
         applied to this DB Instance.
@@ -98,7 +98,7 @@ class DBInstance(object):
         self.auto_minor_version_upgrade = None
         self.endpoint = None
         self.instance_class = None
-        self.master_username = None
+        self.main_username = None
         self.parameter_groups = []
         self.security_groups = []
         self.read_replica_dbinstance_identifiers = []
@@ -172,8 +172,8 @@ class DBInstance(object):
             self.auto_minor_version_upgrade = value.lower() == 'true'
         elif name == 'DBInstanceClass':
             self.instance_class = value
-        elif name == 'MasterUsername':
-            self.master_username = value
+        elif name == 'MainUsername':
+            self.main_username = value
         elif name == 'Port':
             if self._in_endpoint:
                 self._port = int(value)
@@ -293,7 +293,7 @@ class DBInstance(object):
 
     def modify(self, param_group=None, security_groups=None,
                preferred_maintenance_window=None,
-               master_password=None, allocated_storage=None,
+               main_password=None, allocated_storage=None,
                instance_class=None,
                backup_retention_period=None,
                preferred_backup_window=None,
@@ -318,8 +318,8 @@ class DBInstance(object):
             UTC) during which maintenance can occur.  Default is
             Sun:05:00-Sun:09:00
 
-        :type master_password: str
-        :param master_password: Password of master user for the DBInstance.
+        :type main_password: str
+        :param main_password: Password of main user for the DBInstance.
             Must be 4-15 alphanumeric characters.
 
         :type allocated_storage: int
@@ -386,7 +386,7 @@ class DBInstance(object):
                                                  param_group,
                                                  security_groups,
                                                  preferred_maintenance_window,
-                                                 master_password,
+                                                 main_password,
                                                  allocated_storage,
                                                  instance_class,
                                                  backup_retention_period,

--- a/AWSApps/Splunk_TA_aws/bin/3rdparty/boto/rds/dbsnapshot.py
+++ b/AWSApps/Splunk_TA_aws/bin/3rdparty/boto/rds/dbsnapshot.py
@@ -34,10 +34,10 @@ class DBSnapshot(object):
     :ivar id: Specifies the identifier for the DB Snapshot (DBSnapshotIdentifier)
     :ivar instance_create_time: Specifies the time (UTC) when the snapshot was taken
     :ivar instance_id: Specifies the the DBInstanceIdentifier of the DB Instance this DB Snapshot was created from (DBInstanceIdentifier)
-    :ivar master_username: Provides the master username for the DB Instance
+    :ivar main_username: Provides the main username for the DB Instance
     :ivar port: Specifies the port that the database engine was listening on at the time of the snapshot
     :ivar snapshot_create_time: Provides the time (UTC) when the snapshot was taken
-    :ivar status: Specifies the status of this DB Snapshot. Possible values are [ available, backing-up, creating, deleted, deleting, failed, modifying, rebooting, resetting-master-credentials ]
+    :ivar status: Specifies the status of this DB Snapshot. Possible values are [ available, backing-up, creating, deleted, deleting, failed, modifying, rebooting, resetting-main-credentials ]
     :ivar iops: Specifies the Provisioned IOPS (I/O operations per second) value of the DB instance at the time of the snapshot.
     :ivar option_group_name: Provides the option group name for the DB snapshot.
     :ivar percent_progress: The percentage of the estimated data that has been transferred.
@@ -56,7 +56,7 @@ class DBSnapshot(object):
         self.port = None
         self.status = None
         self.availability_zone = None
-        self.master_username = None
+        self.main_username = None
         self.allocated_storage = None
         self.instance_id = None
         self.availability_zone = None
@@ -93,8 +93,8 @@ class DBSnapshot(object):
             self.status = value
         elif name == 'AvailabilityZone':
             self.availability_zone = value
-        elif name == 'MasterUsername':
-            self.master_username = value
+        elif name == 'MainUsername':
+            self.main_username = value
         elif name == 'AllocatedStorage':
             self.allocated_storage = int(value)
         elif name == 'SnapshotTime':

--- a/AWSApps/Splunk_TA_aws/bin/3rdparty/boto/rds2/layer1.py
+++ b/AWSApps/Splunk_TA_aws/bin/3rdparty/boto/rds2/layer1.py
@@ -321,8 +321,8 @@ class RDSConnection(AWSQueryConnection):
             path='/', params=params)
 
     def create_db_instance(self, db_instance_identifier, allocated_storage,
-                           db_instance_class, engine, master_username,
-                           master_user_password, db_name=None,
+                           db_instance_class, engine, main_username,
+                           main_user_password, db_name=None,
                            db_security_groups=None,
                            vpc_security_group_ids=None,
                            availability_zone=None, db_subnet_group_name=None,
@@ -417,9 +417,9 @@ class RDSConnection(AWSQueryConnection):
         Valid Values: `MySQL` | `oracle-se1` | `oracle-se` | `oracle-ee` |
             `sqlserver-ee` | `sqlserver-se` | `sqlserver-ex` | `sqlserver-web`
 
-        :type master_username: string
-        :param master_username:
-        The name of master user for the client DB instance.
+        :type main_username: string
+        :param main_username:
+        The name of main user for the client DB instance.
 
         **MySQL**
 
@@ -452,8 +452,8 @@ class RDSConnection(AWSQueryConnection):
         + First character must be a letter.
         + Cannot be a reserved word for the chosen database engine.
 
-        :type master_user_password: string
-        :param master_user_password: The password for the master database user.
+        :type main_user_password: string
+        :param main_user_password: The password for the main database user.
             Can be any printable ASCII character except "/", '"', or "@".
         Type: String
 
@@ -536,7 +536,7 @@ class RDSConnection(AWSQueryConnection):
 
 
         + Must be a value from 0 to 8
-        + Cannot be set to 0 if the DB instance is a master instance with read
+        + Cannot be set to 0 if the DB instance is a main instance with read
               replicas
 
         :type preferred_backup_window: string
@@ -656,8 +656,8 @@ class RDSConnection(AWSQueryConnection):
             'AllocatedStorage': allocated_storage,
             'DBInstanceClass': db_instance_class,
             'Engine': engine,
-            'MasterUsername': master_username,
-            'MasterUserPassword': master_user_password,
+            'MainUsername': main_username,
+            'MainUserPassword': main_user_password,
         }
         if db_name is not None:
             params['DBName'] = db_name
@@ -2488,7 +2488,7 @@ class RDSConnection(AWSQueryConnection):
                            allocated_storage=None, db_instance_class=None,
                            db_security_groups=None,
                            vpc_security_group_ids=None,
-                           apply_immediately=None, master_user_password=None,
+                           apply_immediately=None, main_user_password=None,
                            db_parameter_group_name=None,
                            backup_retention_period=None,
                            preferred_backup_window=None,
@@ -2616,14 +2616,14 @@ class RDSConnection(AWSQueryConnection):
 
         Default: `False`
 
-        :type master_user_password: string
-        :param master_user_password:
-        The new password for the DB instance master user. Can be any printable
+        :type main_user_password: string
+        :param main_user_password:
+        The new password for the DB instance main user. Can be any printable
             ASCII character except "/", '"', or "@".
 
         Changing this parameter does not result in an outage and the change is
             asynchronously applied as soon as possible. Between the time of the
-            request and the completion of the request, the `MasterUserPassword`
+            request and the completion of the request, the `MainUserPassword`
             element exists in the `PendingModifiedValues` element of the
             operation response.
 
@@ -2634,7 +2634,7 @@ class RDSConnection(AWSQueryConnection):
             characters (SQL Server).
 
         Amazon RDS API actions never return the password, so this action
-            provides a way to regain access to a master instance user if the
+            provides a way to regain access to a main instance user if the
             password is lost.
 
         :type db_parameter_group_name: string
@@ -2668,7 +2668,7 @@ class RDSConnection(AWSQueryConnection):
 
 
         + Must be a value from 0 to 8
-        + Cannot be set to 0 if the DB instance is a master instance with read
+        + Cannot be set to 0 if the DB instance is a main instance with read
               replicas or if the DB instance is a read replica
 
         :type preferred_backup_window: string
@@ -2820,8 +2820,8 @@ class RDSConnection(AWSQueryConnection):
         if apply_immediately is not None:
             params['ApplyImmediately'] = str(
                 apply_immediately).lower()
-        if master_user_password is not None:
-            params['MasterUserPassword'] = master_user_password
+        if main_user_password is not None:
+            params['MainUserPassword'] = main_user_password
         if db_parameter_group_name is not None:
             params['DBParameterGroupName'] = db_parameter_group_name
         if backup_retention_period is not None:

--- a/AWSApps/Splunk_TA_aws/bin/3rdparty/boto/redshift/layer1.py
+++ b/AWSApps/Splunk_TA_aws/bin/3rdparty/boto/redshift/layer1.py
@@ -310,8 +310,8 @@ class RedshiftConnection(AWSQueryConnection):
             verb='POST',
             path='/', params=params)
 
-    def create_cluster(self, cluster_identifier, node_type, master_username,
-                       master_user_password, db_name=None, cluster_type=None,
+    def create_cluster(self, cluster_identifier, node_type, main_username,
+                       main_user_password, db_name=None, cluster_type=None,
                        cluster_security_groups=None,
                        vpc_security_group_ids=None,
                        cluster_subnet_group_name=None,
@@ -391,9 +391,9 @@ class RedshiftConnection(AWSQueryConnection):
         Valid Values: `dw1.xlarge` | `dw1.8xlarge` | `dw2.large` |
             `dw2.8xlarge`.
 
-        :type master_username: string
-        :param master_username:
-        The user name associated with the master user account for the cluster
+        :type main_username: string
+        :param main_username:
+        The user name associated with the main user account for the cluster
             that is being created.
 
         Constraints:
@@ -404,9 +404,9 @@ class RedshiftConnection(AWSQueryConnection):
         + Cannot be a reserved word. A list of reserved words can be found in
               `Reserved Words`_ in the Amazon Redshift Database Developer Guide.
 
-        :type master_user_password: string
-        :param master_user_password:
-        The password associated with the master user account for the cluster
+        :type main_user_password: string
+        :param main_user_password:
+        The password associated with the main user account for the cluster
             that is being created.
 
         Constraints:
@@ -573,8 +573,8 @@ class RedshiftConnection(AWSQueryConnection):
         params = {
             'ClusterIdentifier': cluster_identifier,
             'NodeType': node_type,
-            'MasterUsername': master_username,
-            'MasterUserPassword': master_user_password,
+            'MainUsername': main_username,
+            'MainUserPassword': main_user_password,
         }
         if db_name is not None:
             params['DBName'] = db_name
@@ -2253,7 +2253,7 @@ class RedshiftConnection(AWSQueryConnection):
                        node_type=None, number_of_nodes=None,
                        cluster_security_groups=None,
                        vpc_security_group_ids=None,
-                       master_user_password=None,
+                       main_user_password=None,
                        cluster_parameter_group_name=None,
                        automated_snapshot_retention_period=None,
                        preferred_maintenance_window=None,
@@ -2264,7 +2264,7 @@ class RedshiftConnection(AWSQueryConnection):
         """
         Modifies the settings for a cluster. For example, you can add
         another security or parameter group, update the preferred
-        maintenance window, or change the master user password.
+        maintenance window, or change the main user password.
         Resetting a cluster password or modifying the security groups
         associated with a cluster do not need a reboot. However,
         modifying a parameter group requires a reboot for parameters
@@ -2345,11 +2345,11 @@ class RedshiftConnection(AWSQueryConnection):
         :param vpc_security_group_ids: A list of virtual private cloud (VPC)
             security groups to be associated with the cluster.
 
-        :type master_user_password: string
-        :param master_user_password:
-        The new password for the cluster master user. This change is
+        :type main_user_password: string
+        :param main_user_password:
+        The new password for the cluster main user. This change is
             asynchronously applied as soon as possible. Between the time of the
-            request and the completion of the request, the `MasterUserPassword`
+            request and the completion of the request, the `MainUserPassword`
             element exists in the `PendingModifiedValues` element of the
             operation response.
 
@@ -2464,8 +2464,8 @@ class RedshiftConnection(AWSQueryConnection):
             self.build_list_params(params,
                                    vpc_security_group_ids,
                                    'VpcSecurityGroupIds.member')
-        if master_user_password is not None:
-            params['MasterUserPassword'] = master_user_password
+        if main_user_password is not None:
+            params['MainUserPassword'] = main_user_password
         if cluster_parameter_group_name is not None:
             params['ClusterParameterGroupName'] = cluster_parameter_group_name
         if automated_snapshot_retention_period is not None:

--- a/AWSApps/Splunk_TA_aws/bin/3rdparty/docutils/parsers/rst/states.py
+++ b/AWSApps/Splunk_TA_aws/bin/3rdparty/docutils/parsers/rst/states.py
@@ -137,7 +137,7 @@ class Struct:
 class RSTStateMachine(StateMachineWS):
 
     """
-    reStructuredText's master StateMachine.
+    reStructuredText's main StateMachine.
 
     The entry point to reStructuredText parsing is the `run()` method.
     """

--- a/AWSApps/Splunk_TA_aws/bin/3rdparty/docutils/parsers/rst/tableparser.py
+++ b/AWSApps/Splunk_TA_aws/bin/3rdparty/docutils/parsers/rst/tableparser.py
@@ -534,11 +534,11 @@ class SimpleTableParser(TableParser):
                 self.table[first_body_row:])
 
 
-def update_dict_of_lists(master, newdata):
+def update_dict_of_lists(main, newdata):
     """
-    Extend the list values of `master` with those from `newdata`.
+    Extend the list values of `main` with those from `newdata`.
 
     Both parameters must be dictionaries containing list values.
     """
     for key, values in newdata.items():
-        master.setdefault(key, []).extend(values)
+        main.setdefault(key, []).extend(values)

--- a/AWSApps/Splunk_TA_aws/bin/3rdparty/docutils/utils/math/math2html.py
+++ b/AWSApps/Splunk_TA_aws/bin/3rdparty/docutils/utils/math/math2html.py
@@ -114,7 +114,7 @@ class BibStylesConfig(object):
       u'@incollection':u'$authors: <i>$title</i>{ in <i>$booktitle</i>{ ($editor, ed.)}}.{{ $publisher,} $year.}{ URL <a href="$url">$url</a>.}{ $note.}', 
       u'@inproceedings':u'$authors: “$title”, <i>$booktitle</i>,{ pp. $pages,} $year.{ URL <a href="$url">$url</a>.}{ $note.}', 
       u'@manual':u'$authors: <i>$title</i>.{{ $publisher,} $year.}{ URL <a href="$url">$url</a>.}{ $note.}', 
-      u'@mastersthesis':u'$authors: <i>$title</i>.{{ $publisher,} $year.}{ URL <a href="$url">$url</a>.}{ $note.}', 
+      u'@mainsthesis':u'$authors: <i>$title</i>.{{ $publisher,} $year.}{ URL <a href="$url">$url</a>.}{ $note.}', 
       u'@misc':u'$authors: <i>$title</i>.{{ $publisher,}{ $howpublished,} $year.}{ URL <a href="$url">$url</a>.}{ $note.}', 
       u'@phdthesis':u'$authors: <i>$title</i>.{{ $publisher,} $year.}{ URL <a href="$url">$url</a>.}{ $note.}', 
       u'@proceedings':u'$authors: “$title”, <i>$journal</i>,{ pp. $pages,} $year.{ URL <a href="$url">$url</a>.}{ $note.}', 
@@ -3177,7 +3177,7 @@ class NumberCounter(object):
   name = None
   value = None
   mode = None
-  master = None
+  main = None
 
   letters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
   symbols = NumberingConfig.sequence['symbols']
@@ -3260,25 +3260,25 @@ class NumberCounter(object):
     return result
 
 class DependentCounter(NumberCounter):
-  "A counter which depends on another one (the master)."
+  "A counter which depends on another one (the main)."
 
-  def setmaster(self, master):
-    "Set the master counter."
-    self.master = master
-    self.last = self.master.getvalue()
+  def setmain(self, main):
+    "Set the main counter."
+    self.main = main
+    self.last = self.main.getvalue()
     return self
 
   def getnext(self):
-    "Increase or, if the master counter has changed, restart."
-    if self.last != self.master.getvalue():
+    "Increase or, if the main counter has changed, restart."
+    if self.last != self.main.getvalue():
       self.reset()
     value = NumberCounter.getnext(self)
-    self.last = self.master.getvalue()
+    self.last = self.main.getvalue()
     return value
 
   def getvalue(self):
-    "Get the value of the combined counter: master.dependent."
-    return self.master.getvalue() + '.' + NumberCounter.getvalue(self)
+    "Get the value of the combined counter: main.dependent."
+    return self.main.getvalue() + '.' + NumberCounter.getvalue(self)
 
 class NumberGenerator(object):
   "A number generator for unique sequences and hierarchical structures. Used in:"
@@ -3366,22 +3366,22 @@ class NumberGenerator(object):
     if self.isnumbered(type) and self.getlevel(type) > 1:
       index = self.orderedlayouts.index(type)
       above = self.orderedlayouts[index - 1]
-      master = self.getcounter(above)
-      return self.createdependent(type, master)
+      main = self.getcounter(above)
+      return self.createdependent(type, main)
     counter = NumberCounter(type)
     if self.isroman(type):
       counter.setmode('I')
     return counter
 
-  def getdependentcounter(self, type, master):
+  def getdependentcounter(self, type, main):
     "Get (or create) a counter of the given type that depends on another."
-    if not type in self.counters or not self.counters[type].master:
-      self.counters[type] = self.createdependent(type, master)
+    if not type in self.counters or not self.counters[type].main:
+      self.counters[type] = self.createdependent(type, main)
     return self.counters[type]
 
-  def createdependent(self, type, master):
-    "Create a dependent counter given the master."
-    return DependentCounter(type).setmaster(master)
+  def createdependent(self, type, main):
+    "Create a dependent counter given the main."
+    return DependentCounter(type).setmain(main)
 
   def startappendix(self):
     "Start appendices here."

--- a/AWSApps/Splunk_TA_aws/bin/3rdparty/docutils/writers/odf_odt/__init__.py
+++ b/AWSApps/Splunk_TA_aws/bin/3rdparty/docutils/writers/odf_odt/__init__.py
@@ -1082,7 +1082,7 @@ class ODFTranslator(nodes.GenericNodeVisitor):
         el1 = SubElement(
             self.automatic_styles, 'style:style', attrib={
                 'style:name': style_name,
-                'style:master-page-name': "rststyle-pagedefault",
+                'style:main-page-name': "rststyle-pagedefault",
                 'style:family': "paragraph",
             }, nsdict=SNSD)
         if current_style:
@@ -1140,22 +1140,22 @@ class ODFTranslator(nodes.GenericNodeVisitor):
     def add_header_footer(self, root_el):
         automatic_styles = root_el.find(
             '{%s}automatic-styles' % SNSD['office'])
-        path = '{%s}master-styles' % (NAME_SPACE_1, )
-        master_el = root_el.find(path)
-        if master_el is None:
+        path = '{%s}main-styles' % (NAME_SPACE_1, )
+        main_el = root_el.find(path)
+        if main_el is None:
             return
-        path = '{%s}master-page' % (SNSD['style'], )
-        master_el_container = master_el.findall(path)
-        master_el = None
+        path = '{%s}main-page' % (SNSD['style'], )
+        main_el_container = main_el.findall(path)
+        main_el = None
         target_attrib = '{%s}name' % (SNSD['style'], )
         target_name = self.rststyle('pagedefault')
-        for el in master_el_container:
+        for el in main_el_container:
             if el.get(target_attrib) == target_name:
-                master_el = el
+                main_el = el
                 break
-        if master_el is None:
+        if main_el is None:
             return
-        el1 = master_el
+        el1 = main_el
         if self.header_content or self.settings.custom_header:
             if WhichElementTree == 'lxml':
                 el2 = SubElement(el1, 'style:header', nsdict=SNSD)

--- a/AWSApps/Splunk_TA_aws/bin/3rdparty/splunktaucclib/rest_handler/util.py
+++ b/AWSApps/Splunk_TA_aws/bin/3rdparty/splunktaucclib/rest_handler/util.py
@@ -20,7 +20,7 @@ def get_base_app_name():
     absolute_path = os.path.normpath(main_name)
     parts = absolute_path.split(os.path.sep)
     parts.reverse()
-    for key in ("apps", "slave-apps", "master-apps"):
+    for key in ("apps", "subordinate-apps", "main-apps"):
         try:
             idx = parts.index(key)
             if parts[idx + 1] == "etc":

--- a/AWSApps/Splunk_TA_aws/bin/splunk_ta_aws/modinputs/description/rds_description.py
+++ b/AWSApps/Splunk_TA_aws/bin/splunk_ta_aws/modinputs/description/rds_description.py
@@ -22,7 +22,7 @@ def rds_instances(config, **kwargs):
             "character_set_name", "create_time", "endpoint", "engine",
             "engine_version", "id", "instance_class", "iops",
             "latest_restorable_time", "license_model",
-            "master_username", "multi_az", "parameter_groups",
+            "main_username", "multi_az", "parameter_groups",
             "pending_modified_values", "preferred_backup_window",
             "preferred_maintenance_window",
             "read_replica_dbinstance_identifiers", "status", "status_infos",

--- a/AWSApps/Splunk_TA_aws/bin/splunksdc/collector.py
+++ b/AWSApps/Splunk_TA_aws/bin/splunksdc/collector.py
@@ -127,8 +127,8 @@ class SimpleCollectorTask(object):
         self._worker = None
 
     def start(self, name, params):
-        master_context = logging.ThreadLocalLoggingStack.top()
-        args = (self._identifier, master_context, self._callback, self._app, name, params)
+        main_context = logging.ThreadLocalLoggingStack.top()
+        args = (self._identifier, main_context, self._callback, self._app, name, params)
         worker = multiprocessing.Process(
             target=self._task_procedure, args=args
         )
@@ -149,8 +149,8 @@ class SimpleCollectorTask(object):
             self._worker = None
 
     @classmethod
-    def _task_procedure(cls, identifier, master_context, callback, app, name, params):
-        prefix = '' if not os.name == 'nt' else master_context
+    def _task_procedure(cls, identifier, main_context, callback, app, name, params):
+        prefix = '' if not os.name == 'nt' else main_context
         logging.RootHandler.teardown()
         app.setup_root_logger(identifier)
         with logging.LogContext(prefix=prefix):

--- a/AWSApps/splunk_app_aws/bin/esapi/conf/settings.py
+++ b/AWSApps/splunk_app_aws/bin/esapi/conf/settings.py
@@ -7,7 +7,7 @@
 # implementations that some files may need to be read-write as they get
 # updated dynamically.
 #
-# Before using, be sure to update the MasterSalt as described below.
+# Before using, be sure to update the MainSalt as described below.
 # This settings.py may be used, and contains only very safe defaults.
 #
 # This settings file is Python code, and must be syntactically correct.
@@ -83,10 +83,10 @@ Authenticator_AbsoluteTimeoutDuration = timedelta(minutes=20)
 # Directory in which keys are stored
 Encryptor_KeysLocation = '/tmp/esapi/keyring'
 
-# The master salt is appended to all hashes. 
+# The main salt is appended to all hashes. 
 # WARNING: THIS MUST BE CHANGED FROM THE DEFAULT BY FOLLOWING THE INSTRUCTIONS
 # IN THE README TO GENERATE NEW ENCRYPTION KEYS
-Encryptor_MasterSalt = None
+Encryptor_MainSalt = None
 
 # AES is the most widely used and strongest encryption algorithm
 Encryptor_EncryptionAlgorithm = 'AES'

--- a/AWSApps/splunk_app_aws/bin/esapi/encryptor.py
+++ b/AWSApps/splunk_app_aws/bin/esapi/encryptor.py
@@ -23,7 +23,7 @@ class Encryptor():
     encryption and hashing operations. Implementations should
     rely on a strong cryptographic implementation, such as PyCrypto.
     Implementors should take care to ensure that they initialize their
-    implementation with a strong "master key", and that they protect this secret
+    implementation with a strong "main key", and that they protect this secret
     as much as possible.
     
     Possible future enhancements (depending on feedback) might include:

--- a/AWSApps/splunk_app_aws/bin/esapi/reference/default_encryptor.py
+++ b/AWSApps/splunk_app_aws/bin/esapi/reference/default_encryptor.py
@@ -63,7 +63,7 @@ class DefaultEncryptor(Encryptor):
                 {'algorithm' : self.encrypt_algorithm} )
         
         self.encryption_key_length = ESAPI.security_configuration().get_encryption_key_length()
-        self.master_salt = ESAPI.security_configuration().get_master_salt()
+        self.main_salt = ESAPI.security_configuration().get_main_salt()
         
         # Public key crypto
         self.signing_algorithm = ESAPI.security_configuration().get_digital_signature_algorithm()
@@ -81,18 +81,18 @@ class DefaultEncryptor(Encryptor):
         self.keys_asymmetric_public_location = self.keys_location + "asymmetric-public"
              
     def hash(self, plaintext, salt, iterations=None):
-        # Verify a MasterSalt has been set
-        if not self.master_salt or len(self.master_salt) < 20:
+        # Verify a MainSalt has been set
+        if not self.main_salt or len(self.main_salt) < 20:
             raise Exception(
-                _("There is an error in the application configuration. The MasterSalt has not been set properly. Please see the instructions in the README for setting up a crypto keyring. Currently, Encryptor_MasterSalt=%(value)s") % 
-                {'value' : self.master_salt})
+                _("There is an error in the application configuration. The MainSalt has not been set properly. Please see the instructions in the README for setting up a crypto keyring. Currently, Encryptor_MainSalt=%(value)s") % 
+                {'value' : self.main_salt})
     
         if iterations is None: 
             iterations = self.hash_iterations
     
         try:
             digest = hashlib.new(self.hash_algorithm)
-            digest.update(self.master_salt)
+            digest.update(self.main_salt)
             digest.update(salt)
             digest.update(plaintext)
             
@@ -262,10 +262,10 @@ class DefaultEncryptor(Encryptor):
              "--status=primary",
              "--destination=%s" % self.keys_asymmetric_public_location] )
              
-        # Gen a new master salt
+        # Gen a new main salt
         from os import urandom
         salt = urandom(20)
         print "Please modify this line in esapi/conf/settings.py:"
-        print "Encryptor_MasterSalt = '" + ESAPI.encoder().encode_for_base64(salt) + "'"
+        print "Encryptor_MainSalt = '" + ESAPI.encoder().encode_for_base64(salt) + "'"
              
         print "Done!"

--- a/AWSApps/splunk_app_aws/bin/esapi/reference/default_security_configuration.py
+++ b/AWSApps/splunk_app_aws/bin/esapi/reference/default_security_configuration.py
@@ -65,10 +65,10 @@ class DefaultSecurityConfiguration(SecurityConfiguration):
             
         self.log_special(_("Loaded ESAPI properties"))
         
-        self.log_special(_(" ======Master Configuration======"))
+        self.log_special(_(" ======Main Configuration======"))
         
         for option in dir(settings):
-            if "Master" not in option and option[0] != "_":
+            if "Main" not in option and option[0] != "_":
                 self.log_special("  |   %(key)s = %(value)s" % {"key": option, "value": str(settings.__dict__[option])})
     
     def log_special(self, text):
@@ -173,8 +173,8 @@ class DefaultSecurityConfiguration(SecurityConfiguration):
         return settings.Executor_MaxRunningTime
     
     # Hashing
-    def get_master_salt(self):
-        return ESAPI.encoder().decode_from_base64(settings.Encryptor_MasterSalt)
+    def get_main_salt(self):
+        return ESAPI.encoder().decode_from_base64(settings.Encryptor_MainSalt)
 
     def get_hash_algorithm(self):
         return settings.Encryptor_HashAlgorithm

--- a/AWSApps/splunk_app_aws/bin/esapi/security_configuration.py
+++ b/AWSApps/splunk_app_aws/bin/esapi/security_configuration.py
@@ -28,7 +28,7 @@ class SecurityConfiguration:
     information is stored.
     
     Please note that adding another layer of encryption does not make the
-    attackers job much more difficult. Somewhere there must be a master 
+    attackers job much more difficult. Somewhere there must be a main 
     "secret" that is stored unencrypted on the application platform. Creating 
     another layer of indirection doesn't provide any real additional security. 
     Its up to the reference implementation to decide whether this file should 
@@ -272,12 +272,12 @@ class SecurityConfiguration:
         raise NotImplementedError()        
         
     # Hashing
-    def get_master_salt(self):
+    def get_main_salt(self):
         """
-        Gets the master salt that is used to salt stored password hashes and 
+        Gets the main salt that is used to salt stored password hashes and 
         any other location where a salt is needed.
         
-        @return: the current master salt
+        @return: the current main salt
         """
         raise NotImplementedError()
 


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.